### PR TITLE
Renovate のプリセットを GitHub の hiroxto/renovate-config に変更.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,5 @@
 {
   "extends": [
-    "config:base"
-  ],
-  "timezone": "Asia/Tokyo",
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "before 10am on the 15th day of the month"
-    ]
-  },
-  "pin": {
-    "enabled": true,
-    "automerge": true,
-    "schedule": [
-      "every weekday",
-      "every weekend"
-    ]
-  },
-  "patch": {
-    "automerge": true
-  }
+    "github>hiroxto/renovate-config"
+  ]
 }


### PR DESCRIPTION
Renovate のプリセットを GitHub の hiroxto/renovate-config に変更.

個別で設定を持たずに, 一括して管理する.